### PR TITLE
fix(scraper): rotate on contact reveals, not listings opened

### DIFF
--- a/app/scraper/contact_extractor.py
+++ b/app/scraper/contact_extractor.py
@@ -22,7 +22,7 @@ class ContactExtractor:
 
     def __init__(self, page, images_dir: Path, otp_key: Optional[str] = None,
                  on_pause=None, on_resume=None, should_cancel=None,
-                 account_phone: Optional[str] = None):
+                 account_phone: Optional[str] = None, on_challenge=None):
         self.page = page
         self.images_dir = images_dir
         self.otp_key = otp_key  # key into otp_store; set by scraper when a job is running
@@ -36,6 +36,10 @@ class ContactExtractor:
         self.on_resume = on_resume
         # async predicate: returns True if the job was cancelled → stop waiting
         self.should_cancel = should_cancel
+        # Fired the moment Divar demands a code, before we settle in to wait for
+        # a human. The scraper uses it to rotate to a fresh account instead —
+        # the challenge is this number telling us it is spent.
+        self.on_challenge = on_challenge
 
     async def get_phone_number(self) -> Optional[str]:
         """Click the contact button and return the extracted phone number."""
@@ -358,6 +362,16 @@ class ContactExtractor:
             if not self.otp_key:
                 logger.warning("SMS-OTP modal found but otp_key not set — phone extraction skipped")
                 return
+
+            # Tell the scraper before anything else. Whether a human types the
+            # code or nobody is watching, this account has been challenged and
+            # should be swapped out at the next safe point — that is true even
+            # if the wait below is cancelled or times out.
+            if self.on_challenge:
+                try:
+                    self.on_challenge()
+                except Exception as e:
+                    logger.warning(f"on_challenge callback failed: {e}")
 
             from app.scraper import otp_store
             # If the user already dismissed an OTP prompt this run, don't block

--- a/app/scraper/divar_scraper.py
+++ b/app/scraper/divar_scraper.py
@@ -108,7 +108,14 @@ class DivarScraper:
         # Cookie rotation: cycle through saved Divar accounts mid-scrape so a
         # single number isn't hammered (which is what triggers the SMS checks)
         self._rotation_pool: List[str] = []
-        self._since_rotation = 0
+        # Counts contact-info reveals, not listings. Divar's SMS challenge is
+        # triggered by asking for a phone number, and pre_contact_skip means most
+        # listings never do that — so counting listings measured an event Divar
+        # does not, and the setting could never hold the codes off.
+        self._reveals_since_rotation = 0
+        # Set when Divar demands a code: it is the account itself saying it is
+        # spent, which beats any counter, so the next opportunity rotates.
+        self._force_rotate = False
         self._rotate_every_override: Optional[int] = None
 
         self.current_job: Optional[ScrapingJob] = None
@@ -1387,6 +1394,9 @@ class DivarScraper:
                         f"Not requesting contact info for {property_data.get('divar_id')}: {reason}")
                     return property_data
 
+            # This is the moment Divar counts, so it is the moment we count.
+            self._reveals_since_rotation += 1
+
             contact_extractor = ContactExtractor(
                 self.page, self.images_dir, otp_key=_otp_key,
                 on_pause=_pause_job, on_resume=_resume_job,
@@ -1394,6 +1404,9 @@ class DivarScraper:
                 # the code goes to whichever account is logged in *now*, which
                 # rotation may have changed since the job started
                 account_phone=self.active_phone,
+                # Divar challenging this account is the strongest signal there
+                # is that it needs replacing — louder than any threshold.
+                on_challenge=self._note_account_challenged,
             )
             phone_number = await contact_extractor.get_phone_number()
             if phone_number:
@@ -2287,21 +2300,39 @@ class DivarScraper:
         except Exception as e:
             logger.warning(f"[rotate] could not save session for {self.active_phone}: {e}")
 
+    def _note_account_challenged(self) -> None:
+        """Divar asked this account for an SMS code — rotate at the next chance.
+
+        Called from ContactExtractor the moment the OTP modal appears, before it
+        settles in to wait for a human. Deliberately synchronous and trivial: it
+        runs while a modal is on screen, so it only records the fact. The switch
+        itself happens between listings, where it is safe to navigate.
+        """
+        self._force_rotate = True
+
     async def maybe_rotate_account(self) -> bool:
-        """Every `cookie_rotate_every` listings, switch to the next saved Divar
-        account so Divar sees the load spread across numbers (fewer SMS checks).
+        """Switch Divar account once this one has revealed `cookie_rotate_every`
+        phone numbers, or as soon as Divar challenges it.
+
+        The threshold counts **contact-info reveals**, not listings processed.
+        Divar's SMS check is triggered by asking for a phone number, and
+        pre_contact_skip means a filtered run opens far more listings than it
+        reveals — so a listing-based count drifted further from Divar's the more
+        filtering was applied, and the setting looked like it was being ignored.
 
         Returns True when the active account actually changed.
         """
         override = getattr(self, "_rotate_every_override", None)
         every = override if override is not None else (getattr(settings, "cookie_rotate_every", 0) or 0)
-        if every <= 0:
-            return False
 
-        self._since_rotation += 1
-        if self._since_rotation < every:
-            return False
-        self._since_rotation = 0
+        forced = self._force_rotate
+        # every <= 0 disables the threshold, but never the challenge response:
+        # being asked for a code is Divar telling us to move.
+        if not forced:
+            if every <= 0:
+                return False
+            if self._reveals_since_rotation < every:
+                return False
 
         # Re-read the pool each time rather than caching it for the whole run:
         # a long job outlives the account list, so an account added or marked
@@ -2309,8 +2340,12 @@ class DivarScraper:
         pool = await self._load_rotation_pool()
         if pool:
             self._rotation_pool = pool
-        # nothing to rotate to (single account) — keep going as-is
         if len(self._rotation_pool) < 2:
+            # Only one account exists — there is nothing to rotate to, and that
+            # will not change by asking again on the next listing. Clear the
+            # counters so this does not re-run the pool query every time.
+            self._reveals_since_rotation = 0
+            self._force_rotate = False
             return False
 
         # pick the next phone after the current one
@@ -2334,13 +2369,28 @@ class DivarScraper:
             if restored:
                 previous = self.active_phone
                 self.active_phone = candidate
-                logger.info(f"[rotate] switched Divar account {previous} → {candidate}")
+                # Reset here, not before the attempt. Resetting up front meant a
+                # rotation that could not find a working session still consumed
+                # the whole window, so the next try was a full threshold away —
+                # on the very account that had just proved it needed replacing.
+                self._reveals_since_rotation = 0
+                self._force_rotate = False
+                logger.info(
+                    f"[rotate] switched Divar account {previous} → {candidate}"
+                    f"{' (Divar asked it for a code)' if forced else ''}")
                 # Let the restored session settle before it starts opening ads.
                 # A switch followed instantly by a page load is the part that
                 # reads as automated, not the overall pace.
                 await self._human_like_delay(3.0, 6.0)
                 return True
             logger.warning(f"[rotate] session for {candidate} not usable — trying next")
+
+        # Every candidate failed. Leave the counter high so the next reveal
+        # retries, but back it off a little: restoring a session navigates the
+        # browser, and retrying that on every single listing would cost more
+        # than the rotation saves.
+        self._reveals_since_rotation = max(every - 5, 0) if every > 0 else 0
+        self._force_rotate = False
         logger.info("[rotate] no alternative account could be restored; staying on current")
         return False
 
@@ -2742,13 +2792,12 @@ class DivarScraper:
                         if skip:
                             job.scraped_items = (i + 1) if pool_progress else min(job.new_items, max_items)
                             await self.db_session.commit()
-                            # A dropped listing still cost this account a page
-                            # open and a contact-info request — which is what
-                            # Divar counts before demanding a code. Skipping the
-                            # rotation here let one number carry hundreds of
-                            # requests while the counter barely moved, so the
-                            # setting looked like it was being ignored. It is
-                            # the requests that must be spread, not the saves.
+                            # Still ask, because this is a safe point to switch
+                            # and a challenge may be pending from the previous
+                            # listing. It no longer *advances* anything: a
+                            # dropped listing never reached ContactExtractor, so
+                            # Divar was never asked for anything on its behalf.
+                            # The counter moves where the reveal happens.
                             await self.maybe_rotate_account()
                             await self._human_like_delay()
                             continue

--- a/tests/test_account_rotation.py
+++ b/tests/test_account_rotation.py
@@ -1,0 +1,170 @@
+"""
+Divar account rotation.
+
+The reported symptom was "it should change number every 100 scraped, but it
+sends a code every 20". The setting was not being ignored — it counted listings
+processed, while Divar's SMS challenge counts contact-info reveals. Because
+pre_contact_skip means most listings never ask for a phone number, the two
+diverged further the more filtering was applied.
+
+These tests pin the counted unit, and the two behaviours around it that were
+also wrong: a failed rotation used to consume the whole window, and a challenge
+from Divar did nothing at all.
+"""
+import asyncio
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./_rot.db")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/9")
+os.environ.setdefault("SECRET_KEY", "0123456789abcdef0123456789abcdef")
+os.environ.setdefault("LOGS_PATH", "/tmp")
+os.environ.setdefault("IMAGES_PATH", "/tmp")
+
+
+class FakeAuth:
+    """Stands in for DivarAuth. Records which accounts were restored, and can be
+    told to fail — the interesting cases are the ones where restoring fails."""
+
+    def __init__(self, restorable=True):
+        self.restorable = restorable
+        self.restored = []
+
+    async def restore_session(self, phone):
+        self.restored.append(phone)
+        return self.restorable
+
+
+def make_scraper(pool, every=100, restorable=True):
+    """A DivarScraper with only the rotation collaborators wired up.
+
+    Built with __new__ so none of the browser/filesystem setup in __init__ runs:
+    rotation touches the account pool and the auth object and nothing else, and
+    a test that needed Playwright to check a counter would not be run.
+    """
+    from app.scraper.divar_scraper import DivarScraper
+
+    s = DivarScraper.__new__(DivarScraper)
+    s._rotation_pool = list(pool)
+    s._reveals_since_rotation = 0
+    s._force_rotate = False
+    s._rotate_every_override = every
+    s.active_phone = pool[0] if pool else None
+    s.auth = FakeAuth(restorable=restorable)
+
+    async def _load_pool():
+        return list(pool)
+    s._load_rotation_pool = _load_pool
+
+    async def _persist():
+        return None
+    s._persist_active_session = _persist
+
+    async def _delay(*a, **k):
+        return None
+    s._human_like_delay = _delay
+    return s
+
+
+def reveals(scraper, n):
+    """Simulate n contact-info reveals, rotating between each as the loop does."""
+    switches = 0
+    for _ in range(n):
+        scraper._reveals_since_rotation += 1        # what scrape_property_detail does
+        if asyncio.run(scraper.maybe_rotate_account()):
+            switches += 1
+    return switches
+
+
+# ── the reported bug ─────────────────────────────────────────────────────────
+
+def test_rotation_is_measured_in_contact_reveals():
+    """100 reveals with a threshold of 100 must rotate exactly once."""
+    s = make_scraper(["0911", "0922", "0933"], every=100)
+    assert reveals(s, 99) == 0, "rotated before the threshold"
+    assert reveals(s, 1) == 1, "did not rotate on the 100th reveal"
+    assert s.active_phone == "0922"
+
+
+def test_listings_that_never_reveal_a_phone_do_not_count():
+    """The heart of it. A filtered run opens many listings and reveals few
+    phones; only the reveals may move the counter, because only the reveals are
+    what Divar counts."""
+    s = make_scraper(["0911", "0922"], every=100)
+
+    # 500 listings go by, but pre_contact_skip discards every one, so
+    # scrape_property_detail returns before ContactExtractor is built.
+    for _ in range(500):
+        assert asyncio.run(s.maybe_rotate_account()) is False
+
+    assert s.active_phone == "0911", "rotated on listings that never asked Divar anything"
+    assert s._reveals_since_rotation == 0
+
+    # and the account still has its full budget of reveals
+    assert reveals(s, 99) == 0
+    assert reveals(s, 1) == 1
+
+
+# ── a challenge is louder than the counter ───────────────────────────────────
+
+def test_a_divar_challenge_rotates_immediately():
+    """Being asked for a code is the account saying it is spent. Waiting for the
+    counter after that is waiting for a number Divar has already stopped
+    trusting."""
+    s = make_scraper(["0911", "0922"], every=100)
+    reveals(s, 10)
+    assert s.active_phone == "0911"
+
+    s._note_account_challenged()                    # what ContactExtractor fires
+    assert asyncio.run(s.maybe_rotate_account()) is True
+    assert s.active_phone == "0922"
+    assert s._force_rotate is False, "challenge flag outlived the rotation"
+    assert s._reveals_since_rotation == 0
+
+
+def test_a_challenge_rotates_even_when_the_threshold_is_disabled():
+    """every <= 0 means 'do not rotate on a schedule'. It cannot mean 'ignore
+    Divar telling us the account is finished'."""
+    s = make_scraper(["0911", "0922"], every=0)
+    assert reveals(s, 50) == 0                      # no scheduled rotation
+    s._note_account_challenged()
+    assert asyncio.run(s.maybe_rotate_account()) is True
+    assert s.active_phone == "0922"
+
+
+# ── a failed rotation must not consume the window ────────────────────────────
+
+def test_failed_rotation_retries_soon_instead_of_waiting_a_full_window():
+    """The counter used to be zeroed before the attempt, so when no session
+    could be restored the next try was a full threshold away — on the account
+    that had just proved it needed replacing."""
+    s = make_scraper(["0911", "0922"], every=100, restorable=False)
+    assert reveals(s, 100) == 0                     # nothing restorable
+    assert s.active_phone == "0911"
+    assert s._reveals_since_rotation >= 90, (
+        "a failed rotation reset the counter and gave up the whole window")
+
+    # once a session becomes usable again it recovers within a few reveals,
+    # not another hundred
+    s.auth.restorable = True
+    assert reveals(s, 6) == 1
+
+
+def test_single_account_does_not_re_query_the_pool_forever():
+    """With one account there is nothing to rotate to, and that will not change
+    by asking again on the very next reveal."""
+    s = make_scraper(["0911"], every=10)
+    calls = {"n": 0}
+
+    async def _counting_pool():
+        calls["n"] += 1
+        return ["0911"]
+    s._load_rotation_pool = _counting_pool
+
+    reveals(s, 100)
+    assert s.active_phone == "0911"
+    assert calls["n"] <= 12, f"queried the account pool {calls['n']} times for one account"


### PR DESCRIPTION
Fixes #3 (the rotation half). @sahandmusanezhad — your area, so this is a PR rather than a push to `main`.

## The bug

`چرخش شماره` counted **listings processed**. Divar's SMS challenge counts **contact-info reveals**. `pre_contact_skip` pulls those apart: a filtered listing increments the counter but returns from `scrape_property_detail` *before* `ContactExtractor` is built, so Divar is never asked for anything on its behalf.

A run that opens 100 listings might reveal only 20 phone numbers. Divar challenges at its own threshold — your ~20 — long before our counter reaches 100.

**The setting was never being ignored.** It was denominated in a unit Divar does not measure, and the more filtering applied, the further the two drifted. That is why it looked broken on filtered runs and fine on unfiltered ones.

The counter now increments next to `ContactExtractor`, where the reveal happens.

## Three related fixes

**A challenge did nothing.** Divar demanding a code made the scraper pause and wait up to 5 minutes for a human, then continue on the same number. That challenge is the account saying it is spent — answered by waiting for a person. `ContactExtractor` now fires `on_challenge` when the modal appears and the next safe point rotates.

It fires *before* the wait, so it holds whether the code is typed, dismissed, or times out. And it is honoured even when the threshold is disabled: `every <= 0` means "don't rotate on a schedule", not "ignore Divar".

**A failed rotation burned the whole window.** The counter was zeroed before the code knew a switch was possible, so when nothing restored, the next attempt was a full threshold away — on the account that had just proved it needed replacing. Now it resets only on success, and backs off 5 reveals on failure so retrying doesn't re-navigate the browser every listing.

**A single-account pool re-queried the database on every reveal** past the threshold. Nothing to rotate to, and asking again won't change that.

## Tests

`tests/test_account_rotation.py` — 6 tests, and **all 6 fail against the current `main`**:

```
FAILED test_rotation_is_measured_in_contact_reveals
FAILED test_listings_that_never_reveal_a_phone_do_not_count
FAILED test_a_divar_challenge_rotates_immediately
FAILED test_a_challenge_rotates_even_when_the_threshold_is_disabled
FAILED test_failed_rotation_retries_soon_instead_of_waiting_a_full_window
FAILED test_single_account_does_not_re_query_the_pool_forever
```

The central one drives 500 filtered listings through and asserts the counter never moves. I reverted the fix and watched them go red before trusting them.

Full suite: **425 passed** against PostgreSQL 16.

They build the scraper with `__new__` so no browser or filesystem setup runs — rotation touches only the account pool and the auth object, and a test needing Playwright to check a counter wouldn't get run.

## Two things for you to decide

**1. What is Divar's real threshold?** That it's ~20 reveals is inferred from your description — it fits the code exactly, but I couldn't confirm it without a live scrape. Once this is in, `[rotate]` log lines give you reveals-per-account directly. Set `COOKIE_ROTATE_EVERY` just under whatever the real number turns out to be (15 if it's 20).

**2. Check the UI field before anything else.** `app.js:2058` persists `scraper-rotate-every` to localStorage. If anyone ever typed `20`, every run since has silently reused it while the placeholder still shows `۱۰۰`. That's a separate issue from this fix and could be part of what you were seeing — worth a look at the actual field value.

## Not included

The rest of issue #3 — the shared-session rollback at `divar_scraper.py:2392`, uncapped image decoding, the global OTP suppression, and the ~560 lines across three modules with zero importers. Each is independent; say the word and I'll do them as separate PRs rather than pile them in here.
